### PR TITLE
Handle Overlaping/Discontinuous Parcels

### DIFF
--- a/scripts/01_process_parcel_data.py
+++ b/scripts/01_process_parcel_data.py
@@ -54,15 +54,7 @@ def process_parcels(region):
         # Remove duplicate columns from spatial join
         parcels = parcels[parcels.columns[parcels.columns.isin(gpd.read_file('data/raw/parcels/Parcels_-_Historical_-_2024.shp', rows=1).columns)]]
         
-        print(f"After spatial filter: {len(parcels):,}")
-    
-    # Remove duplicate PINs, keep largest geometry
-    print("\nDeduplicating by PIN10 (keeping largest geometry)...")
-    initial_count = len(parcels)
-    parcels = parcels.sort_values('Shape_Area', ascending=False)
-    parcels = parcels.drop_duplicates(subset='PIN10', keep='first')
-    duplicates_removed = initial_count - len(parcels)
-    print(f"After deduplication: {len(parcels):,} ({duplicates_removed:,} duplicates removed)")
+        print(f"After filtering to Chicago: {len(parcels):,}")
     
     # Reproject to WGS84 (standard web projection)
     if parcels.crs != 'EPSG:4326':

--- a/scripts/01_process_parcel_data.py
+++ b/scripts/01_process_parcel_data.py
@@ -56,11 +56,6 @@ def process_parcels(region):
         
         print(f"After filtering to Chicago: {len(parcels):,}")
     
-    # Reproject to WGS84 (standard web projection)
-    if parcels.crs != 'EPSG:4326':
-        print("\nReprojecting to EPSG:4326 (WGS84)...")
-        parcels = parcels.to_crs('EPSG:4326')
-    
     # Save
     output_path = f'data/processed/{region}_parcels_raw.geojson'
     print(f"\nSaving to {output_path}...")


### PR DESCRIPTION
There are instances in which PIN10s have multiple discontinuous parcels. There are also cases where different PIN10s share space or overlap (residential and commercial condos overlapping). With these changes, the scripts now:

1. Detects the overlap
2. Combines the property values from both parcels
3. Treats them as one merged parcel with the correct building footprint
4. Calculate the value per acre of that merged parcel (accounting for the combined acreage)